### PR TITLE
Add helper files to convert matlab tours to Ipython notebooks.

### DIFF
--- a/python/nb_converter.py
+++ b/python/nb_converter.py
@@ -2,7 +2,7 @@ import os
 import re
 import sys
 
-from template import Notebook
+from nb_template import Notebook
 
 SECTION_HEADING = re.compile('\A%% \w')
 
@@ -24,7 +24,7 @@ def convert(fname):
 
     Takes most of the grunt work out of translating a numerical-tours
     matlab file into an ipython notebook.  It will auto-populate the
-    notebook with headings, markdown, code, and excercises as apppropriate.
+    notebook with headings, markdown, code, and exercises as appropriate.
     Ideally, all one then has to do is translate the code itself.
 
     Some code transformations are in place (see CODE_REPLS and _parse_code 
@@ -59,12 +59,12 @@ def parse_line(line, state):
     new_line = line.decode('utf-8', 'ignore')
     new_state = state
     if state == 'excercise':
-        if new_line.startswith('%'):
-            new_state = 'excercise'
-            new_line = _parse_markdown(new_line)
-        elif new_line.startswith('%EXO'):
+        if new_line.startswith('%EXO'):
             new_state = 'markdown'
             new_line = ''
+        elif new_line.startswith('%'):
+            new_state = 'excercise'
+            new_line = _parse_markdown(new_line)  
         else:
             new_state = 'excercise'
             new_line = ''

--- a/python/nb_template.py
+++ b/python/nb_template.py
@@ -23,6 +23,7 @@ $\newcommand{\dotp}[2]{\langle #1, #2 \rangle}
 \newcommand{\qandq}{\quad\text{and}\quad}
 \newcommand{\qwhereq}{\quad\text{where}\quad}
 \newcommand{\qifq}{ \quad \text{if} \quad }
+\newcommand{\qarrq}{ \quad \Longrightarrow \quad }
 \newcommand{\ZZ}{\mathbb{Z}}
 \newcommand{\RR}{\mathbb{R}}
 \newcommand{\Nn}{\mathcal{N}}
@@ -95,7 +96,7 @@ class Notebook(dict):
                     outputs=outputs)
         self['worksheets'][0]['cells'].append(code)
 
-    def add_excercise(self, source):
+    def add_exercise(self, source):
         self.add_heading('Exercise %s' % self._excercise_num, level=3)
         self._excercise_num += 1
         self.add_markdown(source)


### PR DESCRIPTION
Takes most of the grunt work out of translating a numerical-tours
Matlab file into an IPython notebook.  It will auto-populate the
notebook with headings, markdown, code, and exercises as appropriate.
Ideally, all one then has to do is translate the code itself.

Some code transformations are in place (see `CODE_REPLS` and `_parse_code`).
