### PR TITLE
Modify lena path from lena.bmp to lena.png

### DIFF
--- a/python/coding_1_approximation.ipynb
+++ b/python/coding_1_approximation.ipynb
@@ -140,7 +140,7 @@
    "outputs": [],
    "source": [
     "n = 512\n",
-    "f = rescale(load_image(\"nt_toolbox/data/lena.bmp\", n))"
+    "f = rescale(load_image(\"nt_toolbox/data/lena.png\", n))"
    ]
   },
   {


### PR DESCRIPTION
The file lena.bmp is indeed not present in the toolbox downloaded from the website.