### PR TITLE
Update optim_5_primal_dual.ipynb

### DIFF
--- a/julia/optim_5_primal_dual.ipynb
+++ b/julia/optim_5_primal_dual.ipynb
@@ -127,7 +127,7 @@
     "\n",
     "The algorithm reads:\n",
     "$$ g_{k+1} = \\text{Prox}_{\\sigma F^*}( g_k + \\sigma K(\\tilde f_k) $$\n",
-    "$$ f_{k+1} = \\text{Prox}_{\\tau G}(  f_k-\\tau K^*(g_k) ) $$\n",
+    "$$ f_{k+1} = \\text{Prox}_{\\tau G}(  f_k-\\tau K^*(g_{k+1}) ) $$\n",
     "$$ \\tilde f_{k+1} = f_{k+1} + \\theta (f_{k+1} - f_k) $$\n",
     "\n",
     "\n",


### PR DESCRIPTION
It seems to be a typo in the index of `g_k`, since the value `g_ {k+1}` is computed and then ignored