### PR TITLE
Update perform_front_propagation_3d_mex.cpp

### DIFF
--- a/matlab/toolbox_graph/mex/perform_front_propagation_3d_mex.cpp
+++ b/matlab/toolbox_graph/mex/perform_front_propagation_3d_mex.cpp
@@ -20,6 +20,17 @@
 #include "mex.h"
 
 
+
+// PBR - MKR 20220503
+// old prototype in /Applications/MATLAB_R2021b.app/extern/include/matrix.h
+// LIBMMWMATRIX_PUBLISHED_API_EXTERN_C mxArray *mxCreateNumericArray(mwSize ndim, const mwSize *dims, mxClassID classid, mxComplexity flag);
+// type of param 2 not correct: old = const mwSize *dims   new = const int dims[3]
+#undef mxCreateNumericArray
+LIBMMWMATRIX_PUBLISHED_API_EXTERN_C mxArray * mxCreateNumericArray(mwSize ndim, const int dims[3], mxClassID classid, mxComplexity flag);
+LIBMMWMATRIX_PUBLISHED_API_EXTERN_C mxArray * mxCreateNumericArray(mwSize ndim, const int dims[3], mxClassID classid, mxComplexity flag){
+    return mxCreateNumericArray_730(ndim,(const mwSize *)dims,classid,flag);
+}
+  
 void mexFunction(	int nlhs, mxArray *plhs[], 
 					int nrhs, const mxArray*prhs[] ) 
 { 


### PR DESCRIPTION
undef the preprocess symbol
add new prototype and implement function with correct types for :

- mxCreateNumericArray,

with Matlab 2021a.